### PR TITLE
修复：强制市场条目声明宿主最低版本；

### DIFF
--- a/.github/ISSUE_TEMPLATE/plugin-submission.yml
+++ b/.github/ISSUE_TEMPLATE/plugin-submission.yml
@@ -69,6 +69,25 @@ body:
     validations:
       required: true
 
+  - type: markdown
+    attributes:
+      value: |
+        > 兼容性必填说明
+        >
+        > 如果这个插件要进入官方市场，插件仓库里的 `manifest.json` 必须声明宿主最低版本。
+        >
+        > 推荐写法：
+        >
+        > ```json
+        > {
+        >   "compatibility": {
+        >     "min_app_version": "0.1.0"
+        >   }
+        > }
+        > ```
+        >
+        > 机器人只认插件仓库里的 manifest 声明，不会用 Issue 文本替你补这个字段。
+
   - type: textarea
     id: summary_override
     attributes:
@@ -116,6 +135,8 @@ body:
         - label: 我确认插件源码仓库可以被公开访问。
           required: true
         - label: 我确认 manifest、README、requirements 已经准备好。
+          required: true
+        - label: 我确认 manifest 已声明 compatibility.min_app_version（或 top-level min_app_version）。
           required: true
         - label: 我确认权限和风险声明不是乱填的。
           required: true

--- a/docs/contributing/plugin-submission.md
+++ b/docs/contributing/plugin-submission.md
@@ -18,12 +18,26 @@
 - 可读取的 `manifest.json`
 - 可读取的 README
 - 可读取的 `requirements.txt`
+- `manifest.json` 里已经声明宿主最低版本
 - 清楚的维护者信息
+
+推荐写法：
+
+```json
+{
+  "compatibility": {
+    "min_app_version": "0.1.0"
+  }
+}
+```
+
+机器人不会拿 Issue 文本给你补这个字段。插件仓库里没写，收录流程就会直接失败。
 
 ## 机器人会帮你做什么
 
 - 解析 Issue Form
 - 检查仓库、manifest、README、requirements
+- 检查 `manifest.json` 是否声明 `min_app_version`
 - 生成 `plugins/<plugin_id>/entry.json`
 - 创建或更新机器人 PR
 - 自动补齐流程里需要的 GitHub 标签
@@ -36,6 +50,23 @@
 - 不会替维护者决定你的插件一定该收录
 - 不会自动改 FamilyClaw 实例里的市场源配置
 - 不会绕过 `CODEOWNERS` 和分支保护直接把未审内容塞进正式市场
+- 不会替你猜这个插件最低支持哪个宿主版本
+
+## 兼容性字段为什么现在是硬门槛
+
+FamilyClaw 现在会按市场条目里的 `versions[].min_app_version` 判断插件能不能安装。
+
+如果市场条目缺这个字段，宿主只能把兼容性判定成“未知”，结果就是：
+
+- 市场会显示“最新可兼容版本暂无”
+- 安装按钮会被禁用
+- 用户只能看到“当前不能安全判断宿主兼容性”
+
+所以现在的规则很直接：
+
+1. 插件仓库的 `manifest.json` 必须先声明宿主最低版本
+2. 机器人只会从 manifest 读取这个值，再写进市场条目
+3. manifest 没写，Issue 会校验失败，不会再生成一个“看起来能进市场、实际上不能安装”的条目
 
 ## 重跑方式
 

--- a/plugins/official-weather/entry.json
+++ b/plugins/official-weather/entry.json
@@ -20,7 +20,8 @@
     {
       "version": "0.1.0",
       "git_ref": "main",
-      "artifact_type": "source_archive"
+      "artifact_type": "source_archive",
+      "min_app_version": "0.1.0"
     }
   ],
   "install": {

--- a/schemas/entry.schema.json
+++ b/schemas/entry.schema.json
@@ -53,7 +53,7 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["version", "git_ref", "artifact_type"],
+        "required": ["version", "git_ref", "artifact_type", "min_app_version"],
         "properties": {
           "version": { "type": "string", "minLength": 1 },
           "git_ref": { "type": "string", "minLength": 1 },

--- a/scripts/marketplace_submission_lib.py
+++ b/scripts/marketplace_submission_lib.py
@@ -374,6 +374,25 @@ def validate_generated_entry(entry: dict[str, Any]) -> list[dict[str, str]]:
     versions = entry.get("versions")
     if not isinstance(versions, list) or not versions:
         errors.append({"field": "versions", "error_code": "entry_generation_failed", "detail": "versions 至少要有一个版本。"})
+    if isinstance(versions, list):
+        for index, item in enumerate(versions):
+            if not isinstance(item, dict):
+                errors.append(
+                    {
+                        "field": f"versions[{index}]",
+                        "error_code": "entry_generation_failed",
+                        "detail": "versions 里的每一项都必须是对象。",
+                    }
+                )
+                continue
+            if not normalize_text(str(item.get("min_app_version") or "")):
+                errors.append(
+                    {
+                        "field": f"versions[{index}].min_app_version",
+                        "error_code": "entry_generation_failed",
+                        "detail": "每个市场版本都必须声明 min_app_version，不能生成兼容性未知的条目。",
+                    }
+                )
     latest_version = normalize_text(str(entry.get("latest_version") or ""))
     if isinstance(versions, list) and latest_version:
         version_set = {item.get("version") for item in versions if isinstance(item, dict)}

--- a/scripts/validate_plugin_submission.py
+++ b/scripts/validate_plugin_submission.py
@@ -231,6 +231,12 @@ def validate_submission(
 
         repo_description = normalize_text(str(repo_metadata.get("description") or ""))
         min_app_version = resolve_min_app_version(manifest)
+        if not min_app_version:
+            raise ValidationError(
+                "manifest.json 必须声明宿主最低版本。请在 compatibility.min_app_version（推荐）或 top-level min_app_version 中填写。",
+                error_code="manifest_invalid",
+                field="manifest_path",
+            )
         versions = build_versions(
             manifest_version=manifest_version,
             branch=branch,
@@ -298,6 +304,7 @@ def validate_submission(
                     f"插件 ID：`{plugin_id}`",
                     f"源码仓库：`{repo_info['html_url']}`",
                     f"默认安装版本：`{latest_version}`",
+                    f"最低宿主版本：`{min_app_version}`",
                     "当前可以进入机器人 PR 生成阶段。",
                 ],
                 field_errors=field_errors,


### PR DESCRIPTION
## 这是什么

这个 PR 用来把一个插件收录申请变成正式市场条目。

## 审核前先看

- 先看对应 Issue 里的自动校验结果
- 再看插件源码仓库的 README、manifest、权限和风险声明
- 最后确认 `plugins/<plugin_id>/entry.json` 是否需要人工微调

## 审核清单

- [ ] 插件源码仓库真实可访问
- [ ] manifest、README、requirements 与市场条目能对上
- [ ] 权限和风险等级没有乱写
- [ ] 市场摘要、分类、维护者信息足够清楚
- [ ] 这个插件值得进入正式市场

## 合并规则

- 只有通过审核后才允许合并
- 审核通过后，workflow 会同步 Issue / PR 状态，并在仓库允许时尝试开启自动合并
- 合并后才会进入正式市场同步链路
- 不允许绕过 PR 直接写默认分支
